### PR TITLE
Added part attribute for facet terms and bars

### DIFF
--- a/packages/facets-core/src/facet-bars-value/FacetBarsValue.ts
+++ b/packages/facets-core/src/facet-bars-value/FacetBarsValue.ts
@@ -235,8 +235,9 @@ export class FacetBarsValue extends FacetBlueprint {
             const value = this.values[i];
             if (!isNaN(value)) {
                 const height = (Math.max(Math.min(value, 1), 0) * 100).toFixed(2);
+                const barClass = `facet-bars-value-bar-${n - i - 1}`;
                 result.push(html`
-                <div class="facet-bars-value-bar-${n - i - 1}" style="height: ${height}%"></div>
+                <div class=${barClass} style="height: ${height}%" part=${barClass}></div>
                 `);
             }
         }

--- a/packages/facets-core/src/facet-terms-value/FacetTermsValue.ts
+++ b/packages/facets-core/src/facet-terms-value/FacetTermsValue.ts
@@ -180,8 +180,9 @@ export class FacetTermsValue extends FacetHoverable {
             const value = this.values[i];
             if (!isNaN(value)) {
                 const width = (Math.max(Math.min(value, 1), 0) * 100).toFixed(2);
+                const barClass = `facet-terms-value-bar-${n - i - 1}`;
                 result.push(html`
-                <div class="facet-terms-value-bar-${n - i - 1}" style="width: ${width}%"></div>
+                <div class=${barClass} style="width: ${width}%" part=${barClass}></div>
                 `);
             }
         }


### PR DESCRIPTION
- Adds part attribute to terms and bars example below
![image](https://user-images.githubusercontent.com/25306965/120022169-05610a00-bfba-11eb-94ba-022558b30a4c.png)

The green was generated with the below selector
`
facet-terms-value#\30::part(facet-terms-value-bar-0){
  background-color:green!important;
}
`