### PR TITLE
add deselection to facets-timeline

### DIFF
--- a/packages/facets-core/src/facet-plugin/default/facet-timeline-selection/FacetTimelineSelection.ts
+++ b/packages/facets-core/src/facet-plugin/default/facet-timeline-selection/FacetTimelineSelection.ts
@@ -716,7 +716,13 @@ export class FacetTimelineSelection extends FacetPlugin {
                 --rightIndex;
             }
 
-            if (leftIndex !== rightIndex) {
+            if (
+                host.selection &&
+                host.selection[0] === leftIndex &&
+                host.selection[1] === rightIndex
+            ) {
+                host.selection = null;
+            } else if (leftIndex !== rightIndex) {
                 host.selection = [leftIndex, rightIndex];
             } else {
                 host.selection = null;


### PR DESCRIPTION
I resolved issue #17 by simply setting the selection property back to null if the new selection matches the existing.

![facet-timeline-fixed](https://user-images.githubusercontent.com/17185156/126190673-57447cd2-24b3-44b3-80c1-eda422a59e4b.gif)