### PR TITLE
F2-7442 - dont prevent default for mouse up events as it causes issues

### DIFF
--- a/packages/facets-core/src/facet-plugin/default/facet-timeline-selection/FacetTimelineSelection.ts
+++ b/packages/facets-core/src/facet-plugin/default/facet-timeline-selection/FacetTimelineSelection.ts
@@ -572,7 +572,6 @@ export class FacetTimelineSelection extends FacetPlugin {
                             host.requestUpdate();
                         }
                         mouseEvent.stopPropagation();
-                        mouseEvent.preventDefault();
                         this.mouse.tracking = null;
                         break;
 


### PR DESCRIPTION
Because this event handler is on the root of the document is causes issues when we prevent default for mouse up events. Ive tested facet selection with this change and it appears to function as expected, I'm not certain why we were preventing default for all mouse up events through out the web page.

We will need to do a version bump and publish after this is merged to complete the fix cycle.